### PR TITLE
Support both python2 and python3

### DIFF
--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -14,7 +14,10 @@ or in the "license" file accompanying this file. This file is distributed on an 
 import boto3
 import hashlib
 import json
-import urllib2
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 # Name of the service, as seen in the ip-groups.json file, to extract information for
 SERVICE = "CLOUDFRONT"
@@ -46,7 +49,7 @@ def lambda_handler(event, context):
 def get_ip_groups_json(url, expected_hash):
     print("Updating from " + url)
 
-    response = urllib2.urlopen(url)
+    response = urlopen(url)
     ip_json = response.read()
 
     m = hashlib.md5()
@@ -172,8 +175,8 @@ def add_permissions(client, group, permission, to_add):
     return len(to_add)
 
 def get_security_groups_for_update(client, security_group_tag):
-    filters = list();
-    for key, value in security_group_tag.iteritems():
+    filters = list()
+    for key, value in security_group_tag.items():
         filters.extend(
             [
                 { 'Name': "tag-key", 'Values': [ key ] },


### PR DESCRIPTION
python2 will be EOL in January 2020

This is similar to https://github.com/aws-samples/aws-cloudfront-samples/pull/13/files but it does not remove the python2 support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
