### PR TITLE
Allow using custom tags in the security groups

### DIFF
--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -14,6 +14,7 @@ or in the "license" file accompanying this file. This file is distributed on an 
 import boto3
 import hashlib
 import json
+import os
 import urllib.request, urllib.error, urllib.parse
 
 # Name of the service, as seen in the ip-groups.json file, to extract information for
@@ -21,10 +22,15 @@ SERVICE = "CLOUDFRONT"
 # Ports your application uses that need inbound permissions from the service for
 INGRESS_PORTS = { 'Http' : 80, 'Https': 443 }
 # Tags which identify the security groups you want to update
-SECURITY_GROUP_TAG_FOR_GLOBAL_HTTP = { 'Name': 'cloudfront_g', 'AutoUpdate': 'true', 'Protocol': 'http' }
-SECURITY_GROUP_TAG_FOR_GLOBAL_HTTPS = { 'Name': 'cloudfront_g', 'AutoUpdate': 'true', 'Protocol': 'https' }
-SECURITY_GROUP_TAG_FOR_REGION_HTTP = { 'Name': 'cloudfront_r', 'AutoUpdate': 'true', 'Protocol': 'http' }
-SECURITY_GROUP_TAG_FOR_REGION_HTTPS = { 'Name': 'cloudfront_r', 'AutoUpdate': 'true', 'Protocol': 'https' }
+TAGS = { 
+    'Name': os.environ.get('TagName', 'Name'),
+    'AutoUpdate': os.environ.get('TagAutoUpdate', 'AutoUpdateTag'),
+    'Protocol': os.environ.get('TagProtocol', 'Protocol')
+}
+SECURITY_GROUP_TAG_FOR_GLOBAL_HTTP = { TAGS['Name']: 'cloudfront_g', TAGS['AutoUpdate']: 'true', TAGS['Protocol']: 'http' }
+SECURITY_GROUP_TAG_FOR_GLOBAL_HTTPS = { TAGS['Name']: 'cloudfront_g', TAGS['AutoUpdate']: 'true', TAGS['Protocol']: 'https' }
+SECURITY_GROUP_TAG_FOR_REGION_HTTP = { TAGS['Name']: 'cloudfront_r', TAGS['AutoUpdate']: 'true', TAGS['Protocol']: 'http' }
+SECURITY_GROUP_TAG_FOR_REGION_HTTPS = { TAGS['Name']: 'cloudfront_r', TAGS['AutoUpdate']: 'true', TAGS['Protocol']: 'https' }
 
 def lambda_handler(event, context):
     print(("Received event: " + json.dumps(event, indent=2)))


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Using a custom tag may be useful if we're already using the default
tags for other things. For example, if we're already using the tag
'Name' for cost allocation, or using the tag 'AutoUpdate' to update
packages via AWS Systems Manager.

To use a different (custom) tag, just set the corresponding environments
vars.

For example, you can set:

    TAG_NAME="X-Name"
    TAG_AUTO_UPDATE='X-AutoUpdate'
    TAG_PROTOCOL='X-Protocol'

And then tag your security groups using the tags `X-Name`, `X-AutoUpdate` and
`X-Protocol`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
