### PR TITLE
Switched to urllib3 for requests as its bundled botocore (boto3)

### DIFF
--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -17,7 +17,7 @@ import hashlib
 import json
 import logging
 import os
-import urllib.request, urllib.error, urllib.parse
+import urllib3.request
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +69,8 @@ def lambda_handler(event, context):
 def get_ip_groups_json(url, expected_hash):
     logger.info("Updating from " + url)
 
-    response = urllib.request.urlopen(url)
+    http = urllib3.PoolManager()
+    response = http.request('GET', url)
     ip_json = response.read()
 
     m = hashlib.md5()


### PR DESCRIPTION
*Issue #, if available:*
The requests library used in the script is no longer bundled in botocore
https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/

*Description of changes:*
When the script opens a url it now uses urllib3, which is bundled with botocore
