### PR TITLE
Python3 and generalised

### DIFF
--- a/update_security_groups_lambda/README.md
+++ b/update_security_groups_lambda/README.md
@@ -2,13 +2,12 @@
 
 ## update-security-groups
 
-A Lambda function for updating the **cloudfront** EC2 security group ingress rules
-with the CloudFront IP range changes.
+A Lambda function for updating EC2 security group ingress rules to permit ingress from Amazon CloudFront IPv4 addresses. See [this blog post](https://aws.amazon.com/blogs/security/how-to-automatically-update-your-security-groups-for-amazon-cloudfront-and-aws-waf-by-using-aws-lambda/)for discussion on how to use it and why it is useful.
 
+## Security Groups
 
-## Security Group
+This Lambda function updates security groups based on their tags. You can stipulate some number of ingress protocol/ports in the code. For each protocol/port number you specify, you will need to have 2 security groups (a *regional* and a *global* one). 
 
-This Lambda function updates a total possibility of 4 EC2 security groups tagged as the following:
 *  `Name: cloudfront_g` and `AutoUpdate: true` and a `Protocol` tag with value `http` or `https`.
 *  `Name: cloudfront_r` and `AutoUpdate: true` and a `Protocol` tag with value `http` or `https`.
 

--- a/update_security_groups_lambda/README.md
+++ b/update_security_groups_lambda/README.md
@@ -6,12 +6,21 @@ A Lambda function for updating EC2 security group ingress rules to permit ingres
 
 ## Security Groups
 
-This Lambda function updates security groups based on their tags. You can stipulate some number of ingress protocol/ports in the code. For each protocol/port number you specify, you will need to have 2 security groups (a *regional* and a *global* one). 
+This Lambda function updates security groups based on their tags. You can stipulate some number of ingress protocol/ports in the code. For each protocol/port number you specify, you will need to have 2 security groups (a *regional* and a *global* one).
 
-*  `Name: cloudfront_g` and `AutoUpdate: true` and a `Protocol` tag with value `http` or `https`.
-*  `Name: cloudfront_r` and `AutoUpdate: true` and a `Protocol` tag with value `http` or `https`.
+### Tagging Security Groups to be Managed by this Lambda Function
+For each protocol, create 2 security groups and put the following 3 tags on each one.
 
-**Note:** For CloudFront to properly connect to your origin over HTTP or HTTPS only, you will need two security groups with `Name: cloudfront_g` and `Name: cloudfront_r` set for http or https depending on the protocol used. If you require both HTTP and HTTPS protocols to your origin, you will need a total of 4 security groups.
+1. A global ingress security group:
+  * **Name**: `cloudfront_g`
+  * **AutoUpdate**: `true`
+  * **Protocol**: `http` (or some other value, depends on what you name your protocols in the code)
+2. A regional ingress security group:
+  * **Name**: `cloudfront_r`
+  * **AutoUpdate**: `true`
+  * **Protocol**: `http` (or some other value, depends on what you name your protocols in the code)
+
+If you allow both HTTP and HTTPS, for example, you will have 4 security groups that you will need to attach to your load balancer, EC2 instance, or other internet-facing ENI.
 
 ## Event Source
 

--- a/update_security_groups_lambda/template.yaml
+++ b/update_security_groups_lambda/template.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+Description: Updates security groups to accept ingress from CloudFront edge IPs
+Resources:
+  UpdateCloudfrontSG:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: aws-cloudfront-samples/update_security_groups_lambda/update_security_groups.lambda_handler
+      Runtime: python3.6
+      Description: 'Updates security groups to accept ingress from CloudFront edge IPs'
+      MemorySize: 128
+      Timeout: 15
+      Environment:
+        Variables:
+          DEBUG: 'false'
+#    Events:
+#      awsIPSpace:
+#        Type: 'SNS'
+#        Properties:
+#          Topic: arn:aws:sns:us-east-1:806199016981:AmazonIpSpaceChanged

--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -107,17 +107,13 @@ def update_security_groups(new_ranges, rangeType):
         else:
             tagToFind = REGION_SG_TAGS    
         tagToFind['Protocol'] = curGroup
-        rangeToUpdate = get_security_groups_for_update(client, tagToFind)        
-        logging.info('Found {} groups tagged {}, proto {} to update'.format(
-                str(len(rangeToUpdate)),
-                tagToFind["Name"],
-                curGroup))
+        rangeToUpdate = get_security_groups_for_update(client, tagToFind)
+        msg = 'tagged Name: {}, Protocol: {} to update'.format( tagToFind["Name"], curGroup )
+        logging.info('Found {} groups {}'.format( str(len(rangeToUpdate)), msg )
 
         if len(rangeToUpdate) == 0:
-            result.append( 'No groups tagged Name: {}, Protocol: {} to update'.format(
-              tagToFind["Name"], curGroup ) )
-            logging.warning( 'No groups tagged Name: {}, Protocol: {} to update'.format(
-              tagToFind["Name"], curGroup ) )
+            result.append( 'No groups {}'.format(msg) )
+            logging.warning( 'No groups {}'.format(msg) )
         else:
             if update_security_group(client, rangeToUpdate[0], new_ranges, INGRESS_PORTS[curGroup] ):
                 result.append('Security Group {} updated.'.format( rangeToUpdate[0]['GroupId'] ) )


### PR DESCRIPTION
## Description of Changes

This includes several related changes.

- Updates to the code to use the `python3.6` runtime (and adds a SAM template.yaml file for that purpose)
- The code is now a little more general. You can have 1, 2, 3 or any number of ingress ports that you want to maintain. It's no longer hardwired at 80 and 443. If you have some load balancers on port 80, some on 443, some on 8080, etc. this one function can maintain security groups for all of them.
- It cleans up debugging a little bit and it improves error handling. Since it's now a bit more general, it handles situation where it's asked to update security groups where none match the required criteria.
- It updates the README to reflect the changes and be a little crisper about what's required in the security group tagging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
