### PR TITLE
Improved by adding EvenOrOdd tag

### DIFF
--- a/update_security_groups_lambda/README.md
+++ b/update_security_groups_lambda/README.md
@@ -15,12 +15,14 @@ For each protocol, create 2 security groups and put the following 3 tags on each
   * **Name**: `cloudfront_g`
   * **AutoUpdate**: `true`
   * **Protocol**: `http` (or some other value, depends on what you name your protocols in the code)
+  * **EvenOrOdd**: `even` (or odd)
 2. A regional ingress security group:
   * **Name**: `cloudfront_r`
   * **AutoUpdate**: `true`
   * **Protocol**: `http` (or some other value, depends on what you name your protocols in the code)
+  * **EvenOrOdd**: `even` (or odd)
 
-If you allow both HTTP and HTTPS, for example, you will have 4 security groups that you will need to attach to your load balancer, EC2 instance, or other internet-facing ENI.
+If you allow both HTTP and HTTPS, for example, you will have 8 security groups that you will need to attach to your load balancer, EC2 instance, or other internet-facing ENI.
 
 ## Event Source
 


### PR DESCRIPTION
Improved by adding EvenOrOdd tag allowing to have the double of security groups because of the limite of rules

*Issue #39 *

*Description of changes:*
It looks for "EvenOrOdd" tag on security group expecting the values ​​"even" or "odd". A counter has been added while loops through IPs checking if the counting number is even or odd.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
