### PR TITLE
loop through groups instead of referencing index. its possible to hav…

### DIFF
--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -115,10 +115,11 @@ def update_security_groups(new_ranges, rangeType):
             result.append( 'No groups {}'.format(msg) )
             logging.warning( 'No groups {}'.format(msg) )
         else:
-            if update_security_group(client, rangeToUpdate[0], new_ranges, INGRESS_PORTS[curGroup] ):
-                result.append('Security Group {} updated.'.format( rangeToUpdate[0]['GroupId'] ) )
-            else:
-                result.append('Security Group {} unchanged.'.format( rangeToUpdate[0]['GroupId'] ) )
+            for grp in rangeToUpdate:
+                if update_security_group(client, grp, new_ranges, INGRESS_PORTS[curGroup] ):
+                    result.append('Security Group {} updated.'.format( grp['GroupId'] ) )
+                else:
+                    result.append('Security Group {} unchanged.'.format( grp['GroupId'] ) )
 
     return result
 

--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -115,11 +115,11 @@ def update_security_groups(new_ranges, rangeType):
             result.append( 'No groups {}'.format(msg) )
             logging.warning( 'No groups {}'.format(msg) )
         else:
-            for grp in rangeToUpdate:
-                if update_security_group(client, grp, new_ranges, INGRESS_PORTS[curGroup] ):
-                    result.append('Security Group {} updated.'.format( grp['GroupId'] ) )
+            for securityGroupToUpdate in rangeToUpdate:
+                if update_security_group(client, securityGroupToUpdate, new_ranges, INGRESS_PORTS[curGroup] ):
+                    result.append('Security Group {} updated.'.format( securityGroupToUpdate['GroupId'] ) )
                 else:
-                    result.append('Security Group {} unchanged.'.format( grp['GroupId'] ) )
+                    result.append('Security Group {} unchanged.'.format( securityGroupToUpdate['GroupId'] ) )
 
     return result
 


### PR DESCRIPTION
loop through groups instead of referencing index. its possible to have security groups in multiple vpcs

*Issue #41 , if available:*

*Description of changes:*
loop through groups instead of referencing index. its possible to have security groups in multiple vpcs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
