### PR TITLE
fixed jq / curl syntax so works, tested on linux and mac

### DIFF
--- a/update_security_groups_lambda/update_security_groups.py
+++ b/update_security_groups_lambda/update_security_groups.py
@@ -47,7 +47,7 @@ def lambda_handler(event, context):
     # If you want a different service, set the SERVICE environment variable.
     # It defaults to CLOUDFRONT. Using 'jq' and 'curl' get the list of possible
     # services like this:
-    # curl -s 'https://ip-ranges.amazonaws.com/ip-ranges.json' | jq -r '.prefixes[] | .service' ip-ranges.json | sort -u 
+    #  curl -s 'https://ip-ranges.amazonaws.com/ip-ranges.json' | jq -r '.prefixes[].service' | sort -u
     SERVICE = os.getenv( 'SERVICE', "CLOUDFRONT")
     
     message = json.loads(event['Records'][0]['Sns']['Message'])


### PR DESCRIPTION
*Issue #, if available:*

closes #49 

*Description of changes:*

Changed comment to have correct syntax to obtain service list from published services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
