### PR TITLE
cloudfront dns update script for CNAME swap

### DIFF
--- a/update_cloudfront_r53_dns_record/README.md
+++ b/update_cloudfront_r53_dns_record/README.md
@@ -18,7 +18,7 @@ This Python automation script **significantly reduces downtime** for CloudFront 
 
 ## When to Use This Script
 
-This script is specifically designed for scenarios where **AWS Support is moving an alternate domain name** between CloudFront distributions. According to AWS documentation, there are [multiple options for moving alternate domain names](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-options.html#alternate-domain-names-move-contact-support), and this automation is only useful when you need to **contact AWS Support** to perform the move.
+This script is specifically designed for scenarios where **AWS Support is moving an alternate domain name** between CloudFront distributions. According to AWS documentation, there are [multiple options for moving alternate domain names](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-options.html#alternate-domain-names-move-contact-support), and this automation is useful when you need to **contact AWS Support** to perform the move.
 
 **Use this script when:**
 - You need AWS Support to move an alternate domain name between distributions
@@ -33,17 +33,17 @@ For more details on when AWS Support assistance is required, see: [Contact AWS S
 
 When AWS Support performs a CNAME swap between CloudFront distributions, TLS connections break immediately after the swap until the customer updates their DNS record to point to the new distribution. This creates downtime that can be problematic for applications with strict uptime requirements.
 
-## Downtime Reduction Solution
+## Lower Downtime during alternate domain updates
 
-This **Python-powered automation** transforms manual CNAME migrations into streamlined, low-downtime operations:
+This **Python-powered automation** simplfies CNAME migration, lowers the downtime and eliminates manual errors:
 
 1. **Parameter Validation** - Validates all required parameters exist and are non-empty
 2. **Domain Verification** - Confirms the provided CloudFront domain matches the actual distribution
-3. **Real-time Monitoring** - Continuously polls the target CloudFront distribution for alias changes
+3. **Real-time Monitoring** - Continuously polls (with delay and jitter) the target CloudFront distribution for alias changes
 4. **IPv6 Detection** - Automatically detects if IPv6 is enabled on the distribution
 5. **Instant Detection** - Identifies the moment AWS Support completes the CNAME swap
 6. **Automated DNS Updates** - Immediately updates Route 53 records (A and/or AAAA) using UPSERT operations
-7. **API Protection** - Uses jitter (10-15 second intervals) to protect CloudFront API from rate limiting
+
 
 ## Prerequisites
 
@@ -87,7 +87,7 @@ python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG d2mz62f
 - Displays IPv6 status of the distribution
 
 ### Monitoring Phase
-- Polls the CloudFront distribution every 10-15 seconds (with random jitter)
+- Polls the CloudFront distribution every 3-8 seconds (with random jitter)
 - Waits for the specified alias to appear in the distribution's aliases
 - Provides clear status messages during the wait
 
@@ -108,9 +108,9 @@ Both record types point to the same CloudFront domain and use the CloudFront hos
 ## API Protection
 
 To protect the CloudFront API from rate limiting:
-- Base delay of 10 seconds between API calls
+- Base delay of 3 seconds between API calls
 - Random jitter of 0-5 seconds added to each delay
-- Total delay ranges from 10-15 seconds between requests
+- Total delay ranges from 3-8 seconds between requests
 - Prevents thundering herd problems when multiple instances run
 
 ## Cross-Account Support

--- a/update_cloudfront_r53_dns_record/README.md
+++ b/update_cloudfront_r53_dns_record/README.md
@@ -1,0 +1,73 @@
+# Automating CloudFront CNAME Migrations: A Zero-Downtime Approach Using Python
+
+**Author:** Trevor Henning (hthennin)
+
+## Overview
+
+This Python automation script delivers a **zero-downtime approach** for CloudFront CNAME migrations by automatically updating DNS records the moment AWS Support completes a CNAME swap. Instead of manual coordination that leads to inevitable downtime, this solution continuously monitors your target CloudFront distribution and instantly updates Route 53 records when the migration occurs.
+
+**Key Benefits:**
+- ✅ **Zero-downtime migrations** - Eliminates the gap between CNAME swap and DNS updates
+- ⚡ **Instant response** - Automated detection and DNS updates within seconds
+- 🔄 **Continuous monitoring** - No manual timing coordination required
+- 🛡️ **TLS protection** - Prevents certificate errors during transitions
+
+## Problem Statement
+
+When AWS Support performs a CNAME swap between CloudFront distributions, TLS connections break immediately after the swap until the customer updates their DNS record to point to the new distribution. This creates downtime that can be problematic for applications with strict uptime requirements.
+
+## Zero-Downtime Solution
+
+This **Python-powered automation** transforms manual CNAME migrations into seamless, zero-downtime operations:
+
+1. **Real-time Monitoring** - Continuously polls the target CloudFront distribution for CNAME changes
+2. **Instant Detection** - Identifies the moment AWS Support completes the CNAME swap
+3. **Automated DNS Updates** - Immediately updates Route 53 records to point to the new distribution
+4. **Downtime Elimination** - Reduces the traditional downtime window from minutes to mere seconds
+
+## Prerequisites
+
+- Python 3.x
+- AWS SDK for Python (Boto3)
+- Appropriate AWS credentials configured
+- IAM permissions for CloudFront and Route 53 operations
+
+## Installation
+
+```bash
+pip install boto3
+```
+
+## Usage
+
+Run the script from the command line with the following parameters:
+
+```bash
+python3 cloudfront_dns_automation.py <new-distribution-id> <route53-hosted-zone-id> <old-cloudfront-domain> <new-cloudfront-domain> <alias-alternate-name>
+```
+
+### Example
+
+```bash
+python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG d2szizvz5rw5zj.cloudfront.net. d2mz62fpvuge8k.cloudfront.net. www.example.com
+```
+
+## Cross-Account Support
+
+The script includes examples for assuming IAM roles when CloudFront distributions or Route 53 hosted zones are in different AWS accounts. Uncomment and modify the role assumption code as needed.
+
+## Zero-Downtime Considerations
+
+- **Maintenance Windows**: This automation enables CNAME swaps outside traditional maintenance windows by achieving near-zero downtime
+- **DNS Propagation**: While the script eliminates coordination delays, global DNS propagation still takes 1-2 minutes
+- **Continuous Operation**: The Python script runs continuously until the swap is detected, requiring no manual intervention
+- **Production Ready**: Designed for high-availability applications with strict uptime requirements
+
+## References
+
+- [Moving an alternate domain name to a different distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move.html#alternate-domain-names-move-options)
+- [AWS IAM Role Switching](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html)
+
+## Support
+
+This script is provided as a reference implementation. Customers should test thoroughly in their environment and modify as needed for their specific use case.

--- a/update_cloudfront_r53_dns_record/README.md
+++ b/update_cloudfront_r53_dns_record/README.md
@@ -1,29 +1,49 @@
-# Automating CloudFront CNAME Migrations: A Zero-Downtime Approach Using Python
+# CloudFront CNAME Swap DNS Automation Script
 
-**Author:** Trevor Henning (hthennin)
+**Original Author:** Trevor Henning (hthennin)  
+**Enhanced Version:** Derived from Trevor's original work with additional features and improvements
 
 ## Overview
 
-This Python automation script delivers a **zero-downtime approach** for CloudFront CNAME migrations by automatically updating DNS records the moment AWS Support completes a CNAME swap. Instead of manual coordination that leads to inevitable downtime, this solution continuously monitors your target CloudFront distribution and instantly updates Route 53 records when the migration occurs.
+This Python automation script **significantly reduces downtime** for CloudFront CNAME migrations by automatically updating DNS records the moment AWS Support completes a CNAME swap. The script monitors a CloudFront distribution for alias changes and automatically updates Route 53 DNS records with comprehensive IPv4 and IPv6 support.
 
-**Key Benefits:**
-- ✅ **Zero-downtime migrations** - Eliminates the gap between CNAME swap and DNS updates
-- ⚡ **Instant response** - Automated detection and DNS updates within seconds
-- 🔄 **Continuous monitoring** - No manual timing coordination required
+**Key Features:**
+- ✅ **Minimized downtime** - Eliminates manual coordination delays between CNAME swap and DNS updates
+- ⚡ **Instant response** - Automated detection and DNS updates within seconds of alias availability
+- 🔄 **Continuous monitoring** - Polls CloudFront distribution with API-friendly jitter
 - 🛡️ **TLS protection** - Prevents certificate errors during transitions
+- 🌐 **IPv6 support** - Automatically handles both A and AAAA records
+- 🔍 **Domain validation** - Ensures provided domain matches actual CloudFront distribution
+- 📊 **Comprehensive validation** - Input parameter validation and error handling
+
+## When to Use This Script
+
+This script is specifically designed for scenarios where **AWS Support is moving an alternate domain name** between CloudFront distributions. According to AWS documentation, there are [multiple options for moving alternate domain names](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-options.html#alternate-domain-names-move-contact-support), and this automation is only useful when you need to **contact AWS Support** to perform the move.
+
+**Use this script when:**
+- You need AWS Support to move an alternate domain name between distributions
+- The alternate domain name is currently in use and cannot be temporarily removed
+- You want to minimize downtime during the migration process
+- You want to automate the DNS update process after AWS Support completes the CNAME swap
+
+
+For more details on when AWS Support assistance is required, see: [Contact AWS Support to move an alternate domain name](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-options.html#alternate-domain-names-move-contact-support)
 
 ## Problem Statement
 
 When AWS Support performs a CNAME swap between CloudFront distributions, TLS connections break immediately after the swap until the customer updates their DNS record to point to the new distribution. This creates downtime that can be problematic for applications with strict uptime requirements.
 
-## Zero-Downtime Solution
+## Downtime Reduction Solution
 
-This **Python-powered automation** transforms manual CNAME migrations into seamless, zero-downtime operations:
+This **Python-powered automation** transforms manual CNAME migrations into streamlined, low-downtime operations:
 
-1. **Real-time Monitoring** - Continuously polls the target CloudFront distribution for CNAME changes
-2. **Instant Detection** - Identifies the moment AWS Support completes the CNAME swap
-3. **Automated DNS Updates** - Immediately updates Route 53 records to point to the new distribution
-4. **Downtime Elimination** - Reduces the traditional downtime window from minutes to mere seconds
+1. **Parameter Validation** - Validates all required parameters exist and are non-empty
+2. **Domain Verification** - Confirms the provided CloudFront domain matches the actual distribution
+3. **Real-time Monitoring** - Continuously polls the target CloudFront distribution for alias changes
+4. **IPv6 Detection** - Automatically detects if IPv6 is enabled on the distribution
+5. **Instant Detection** - Identifies the moment AWS Support completes the CNAME swap
+6. **Automated DNS Updates** - Immediately updates Route 53 records (A and/or AAAA) using UPSERT operations
+7. **API Protection** - Uses jitter (10-15 second intervals) to protect CloudFront API from rate limiting
 
 ## Prerequisites
 
@@ -43,29 +63,81 @@ pip install boto3
 Run the script from the command line with the following parameters:
 
 ```bash
-python3 cloudfront_dns_automation.py <new-distribution-id> <route53-hosted-zone-id> <old-cloudfront-domain> <new-cloudfront-domain> <alias-alternate-name>
+python3 cloudfront_dns_automation.py <new-distribution-id> <route53-hosted-zone-id> <new-cloudfront-domain> <alias-alternate-name>
 ```
+
+### Parameters
+
+- `new-distribution-id`: CloudFront distribution ID to monitor
+- `route53-hosted-zone-id`: Route 53 hosted zone ID containing the DNS record
+- `new-cloudfront-domain`: CloudFront domain name (e.g., d2mz62fpvuge8k.cloudfront.net)
+- `alias-alternate-name`: DNS alias to update (e.g., www.example.com)
 
 ### Example
 
 ```bash
-python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG d2szizvz5rw5zj.cloudfront.net. d2mz62fpvuge8k.cloudfront.net. www.example.com
+python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG d2mz62fpvuge8k.cloudfront.net. www.example.com
 ```
+
+## Script Behavior
+
+### Validation Phase
+- Checks that all required parameters are provided and non-empty
+- Validates the CloudFront domain matches the actual distribution domain
+- Displays IPv6 status of the distribution
+
+### Monitoring Phase
+- Polls the CloudFront distribution every 10-15 seconds (with random jitter)
+- Waits for the specified alias to appear in the distribution's aliases
+- Provides clear status messages during the wait
+
+### Update Phase
+- Creates/updates DNS records using UPSERT operations
+- Handles both IPv4 (A) and IPv6 (AAAA) records based on distribution configuration
+- Provides confirmation of record types updated
+
+## IPv6 Support
+
+The script automatically detects if IPv6 is enabled on the CloudFront distribution:
+
+- **IPv6 Disabled**: Creates only A (IPv4) records
+- **IPv6 Enabled**: Creates both A (IPv4) and AAAA (IPv6) records
+
+Both record types point to the same CloudFront domain and use the CloudFront hosted zone ID (Z2FDTNDATAQYW2).
+
+## API Protection
+
+To protect the CloudFront API from rate limiting:
+- Base delay of 10 seconds between API calls
+- Random jitter of 0-5 seconds added to each delay
+- Total delay ranges from 10-15 seconds between requests
+- Prevents thundering herd problems when multiple instances run
 
 ## Cross-Account Support
 
-The script includes examples for assuming IAM roles when CloudFront distributions or Route 53 hosted zones are in different AWS accounts. Uncomment and modify the role assumption code as needed.
+The script includes commented examples for assuming IAM roles when CloudFront distributions or Route 53 hosted zones are in different AWS accounts. Uncomment and modify the role assumption code as needed.
 
-## Zero-Downtime Considerations
+## Error Handling
 
-- **Maintenance Windows**: This automation enables CNAME swaps outside traditional maintenance windows by achieving near-zero downtime
-- **DNS Propagation**: While the script eliminates coordination delays, global DNS propagation still takes 1-2 minutes
-- **Continuous Operation**: The Python script runs continuously until the swap is detected, requiring no manual intervention
-- **Production Ready**: Designed for high-availability applications with strict uptime requirements
+- **Parameter validation**: Clear error messages for missing or invalid parameters
+- **Domain mismatch**: Fails fast if provided domain doesn't match distribution
+- **API errors**: Graceful handling of AWS API exceptions
+- **Missing aliases**: Handles distributions without alias configuration
+
+## Downtime Reduction Considerations
+
+- **Reduced Downtime**: This automation significantly reduces downtime by eliminating manual coordination delays
+- **DNS Propagation**: The primary remaining downtime is due to global DNS propagation (typically 1-2 minutes)
+- **Instant DNS Updates**: The script updates DNS records within seconds of alias availability
+- **Maintenance Windows**: Enables CNAME swaps with minimal downtime impact
+- **Continuous Operation**: The script runs continuously until the swap is detected
+- **Production Ready**: Designed for high-availability applications seeking to minimize downtime
+- **UPSERT Operations**: Uses UPSERT instead of DELETE/CREATE for safer DNS updates
 
 ## References
 
 - [Moving an alternate domain name to a different distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move.html#alternate-domain-names-move-options)
+- [Contact AWS Support to move an alternate domain name](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/alternate-domain-names-move-options.html#alternate-domain-names-move-contact-support)
 - [AWS IAM Role Switching](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html)
 
 ## Support

--- a/update_cloudfront_r53_dns_record/cloudfront_dns_automation.py
+++ b/update_cloudfront_r53_dns_record/cloudfront_dns_automation.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+CloudFront CNAME Swap DNS Automation Script
+
+Author: Trevor Henning (hthennin)
+
+This script monitors a CloudFront distribution for a CNAME swap and automatically
+updates the corresponding Route 53 DNS record to minimize downtime.
+
+Usage:
+    python3 cloudfront_dns_automation.py <new-distribution-id> <route53-hosted-zone-id> 
+                                        <old-cloudfront-domain> <new-cloudfront-domain> 
+                                        <alias-alternate-name>
+
+Example:
+    python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG 
+                                        d2szizvz5rw5zj.cloudfront.net. 
+                                        d2mz62fpvuge8k.cloudfront.net. 
+                                        www.example.com
+"""
+
+import boto3 
+import json
+import sys
+
+session = boto3.Session()
+r53 = session.client('route53')
+cf = session.client('cloudfront')
+sts = session.client('sts') #to assume a role if needed
+
+def checkAlias(cloudfrontID, alias):
+    response = cf.get_distribution(Id=cloudfrontID)
+    print(response["Distribution"]["DistributionConfig"]["Aliases"]["Items"])
+    while (alias not in response["Distribution"]["DistributionConfig"]["Aliases"]["Items"]):
+        response = cf.get_distribution(Id=cloudfrontID) 
+    return True
+
+def updateRecord(hostedzoneID, old_domain, new_domain, alias):
+    #To assume a role to update a record or all an API in another account, please follow our guides here: 
+    #https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html 
+     
+    #For example, please see the below sample process to assume a role to make a call in Route 53
+    #1. assume role 
+    #sts_response = sts.assume_role(RoleArn="role-ARN-here", RoleSessionName="session-name-here")
+    #temp_credentials = sts_response["Credentials"]
+
+    #2. Create r53 resource w/ new credentials 
+    #r53_resource = boto3.resource(
+    #    "route53",
+    #    aws_access_key_id=temp_credentials["AccessKeyId"],
+    #    aws_secret_access_key=temp_credentials["SecretAccessKey"],
+    #    aws_session_token=temp_credentials["SessionToken"],
+    #)
+    #3. Call the below call w/ new r53 resource, for ex: use r53_resource.change_resource_record_sets, instead of the below r53.change_resource_record_sets
+
+    response = r53.change_resource_record_sets(
+    HostedZoneId=hostedzoneID,
+    ChangeBatch={
+        'Comment': 'string',
+        'Changes': [
+            {
+                'Action': 'DELETE',
+                'ResourceRecordSet': {
+                    'Name': alias,
+                    'Type': 'A',
+                    'AliasTarget': {
+                        'HostedZoneId': 'Z2FDTNDATAQYW2',
+                        'DNSName': old_domain,
+                        'EvaluateTargetHealth': False
+                    }
+                }
+            },
+                        {
+                'Action': 'CREATE',
+                'ResourceRecordSet': {
+                    'Name': alias,
+                    'Type': 'A',
+                    'AliasTarget': {
+                        'HostedZoneId': 'Z2FDTNDATAQYW2',
+                        'DNSName':new_domain,
+                        'EvaluateTargetHealth': False
+                    }
+                }
+            },
+        ]
+    }
+)
+
+
+def main():
+    cloudfrontID = sys.argv[1]
+    hostedzoneID = sys.argv[2]
+    old_domain = sys.argv[3]
+    new_domain = sys.argv[4]
+    alias = sys.argv[5]
+    while checkAlias(cloudfrontID, alias) != True:
+        print("Checking...")
+    updateRecord(hostedzoneID, old_domain, new_domain, alias)
+    print("Record Updated!")
+
+if __name__ == "__main__":
+    main()

--- a/update_cloudfront_r53_dns_record/cloudfront_dns_automation.py
+++ b/update_cloudfront_r53_dns_record/cloudfront_dns_automation.py
@@ -2,101 +2,245 @@
 """
 CloudFront CNAME Swap DNS Automation Script
 
-Author: Trevor Henning (hthennin)
+Original Author: Trevor Henning (hthennin)
+Enhanced Version: Derived from Trevor's original work with additional features
 
 This script monitors a CloudFront distribution for a CNAME swap and automatically
-updates the corresponding Route 53 DNS record to minimize downtime.
+updates the corresponding Route 53 DNS record to minimize downtime. It supports
+both IPv4 (A) and IPv6 (AAAA) records based on the CloudFront distribution configuration.
+
+Enhancements include:
+- IPv6 support with automatic A and AAAA record handling
+- Domain validation against actual CloudFront distribution
+- API rate limiting protection with jitter
+- Comprehensive input validation and error handling
+- UPSERT operations for safer DNS updates
 
 Usage:
     python3 cloudfront_dns_automation.py <new-distribution-id> <route53-hosted-zone-id> 
-                                        <old-cloudfront-domain> <new-cloudfront-domain> 
-                                        <alias-alternate-name>
+                                        <new-cloudfront-domain> <alias-alternate-name>
 
 Example:
     python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG 
-                                        d2szizvz5rw5zj.cloudfront.net. 
                                         d2mz62fpvuge8k.cloudfront.net. 
                                         www.example.com
 """
 
-import boto3 
+import boto3
 import json
 import sys
+import time
+import random
 
 session = boto3.Session()
 r53 = session.client('route53')
 cf = session.client('cloudfront')
-sts = session.client('sts') #to assume a role if needed
+sts = session.client('sts')  # to assume a role if needed
 
-def checkAlias(cloudfrontID, alias):
-    response = cf.get_distribution(Id=cloudfrontID)
-    print(response["Distribution"]["DistributionConfig"]["Aliases"]["Items"])
-    while (alias not in response["Distribution"]["DistributionConfig"]["Aliases"]["Items"]):
-        response = cf.get_distribution(Id=cloudfrontID) 
+
+def validate_inputs(cloudfront_id, hosted_zone_id, new_domain, alias):
+    """
+    Validate all input parameters before processing.
+
+    Args:
+        cloudfront_id (str): CloudFront distribution ID
+        hosted_zone_id (str): Route 53 hosted zone ID
+        new_domain (str): New CloudFront domain name
+        alias (str): DNS alias name
+
+    Raises:
+        ValueError: If any parameter is invalid
+    """
+    errors = []
+
+    # Check if CloudFront distribution ID exists and is non-empty
+    if not cloudfront_id or not isinstance(cloudfront_id, str) or not cloudfront_id.strip():
+        errors.append(
+            "CloudFront distribution ID is required and must be a non-empty string")
+
+    # Check if Route 53 hosted zone ID exists and is non-empty
+    if not hosted_zone_id or not isinstance(hosted_zone_id, str) or not hosted_zone_id.strip():
+        errors.append(
+            "Route 53 hosted zone ID is required and must be a non-empty string")
+
+    # Check if new domain exists and is non-empty
+    if not new_domain or not isinstance(new_domain, str) or not new_domain.strip():
+        errors.append(
+            "New CloudFront domain is required and must be a non-empty string")
+
+    # Check if alias exists and is non-empty
+    if not alias or not isinstance(alias, str) or not alias.strip():
+        errors.append("DNS alias is required and must be a non-empty string")
+
+    if errors:
+        error_message = "Input validation failed:\n" + \
+            "\n".join(f"- {error}" for error in errors)
+        raise ValueError(error_message)
+
     return True
 
-def updateRecord(hostedzoneID, old_domain, new_domain, alias):
-    #To assume a role to update a record or all an API in another account, please follow our guides here: 
-    #https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html 
-     
-    #For example, please see the below sample process to assume a role to make a call in Route 53
-    #1. assume role 
-    #sts_response = sts.assume_role(RoleArn="role-ARN-here", RoleSessionName="session-name-here")
-    #temp_credentials = sts_response["Credentials"]
 
-    #2. Create r53 resource w/ new credentials 
-    #r53_resource = boto3.resource(
+def checkAlias(cloudfrontID, alias, expected_domain):
+    response = cf.get_distribution(Id=cloudfrontID)
+
+    # Validate that the expected domain matches the actual CloudFront domain
+    actual_domain = response["Distribution"]["DomainName"]
+    print(f"CloudFront distribution domain: {actual_domain}")
+
+    if expected_domain.rstrip('.') != actual_domain.rstrip('.'):
+        raise ValueError(
+            f"Domain mismatch: Expected '{expected_domain}' but distribution has '{actual_domain}'")
+
+    # Safely get aliases with proper error handling
+    try:
+        aliases = response["Distribution"]["DistributionConfig"]["Aliases"]["Items"]
+    except KeyError:
+        aliases = []
+
+    # Handle case where aliases can be empty or None
+    if aliases:
+        print(f"Current aliases: {aliases}")
+    else:
+        print("No aliases currently configured")
+
+    while not aliases or alias not in aliases:
+        # Add jitter and delay -- too much of delay will result in a delayed DNS update. 
+        base_delay = 3  # Base delay of 3 seconds
+        jitter = random.uniform(0, 5)  # Random jitter between 0-5 seconds
+        total_delay = base_delay + jitter
+
+        print(f"Waiting {total_delay:.1f} seconds before next check...")
+        time.sleep(total_delay)
+
+        response = cf.get_distribution(Id=cloudfrontID)
+
+        # Safely get aliases in the loop as well
+        try:
+            aliases = response["Distribution"]["DistributionConfig"]["Aliases"]["Items"]
+        except KeyError:
+            aliases = []
+
+        if not aliases:
+            print("Waiting for aliases to be configured...")
+        elif alias not in aliases:
+            print(
+                f"Waiting for alias '{alias}' to be added. Current aliases: {aliases}")
+
+    # Check IPv6 status
+    ipv6_enabled = response["Distribution"]["DistributionConfig"].get(
+        "IsIPV6Enabled", False)
+    print(f"IPv6 enabled: {ipv6_enabled}")
+
+    return ipv6_enabled
+
+
+def updateRecord(hostedzoneID, new_domain, alias, ipv6_enabled=False):
+    # To assume a role to update a record or all an API in another account, please follow our guides here:
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-api.html
+
+    # For example, please see the below sample process to assume a role to make a call in Route 53
+    # 1. assume role
+    # sts_response = sts.assume_role(RoleArn="role-ARN-here", RoleSessionName="session-name-here")
+    # temp_credentials = sts_response["Credentials"]
+
+    # 2. Create r53 resource w/ new credentials
+    # r53_resource = boto3.resource(
     #    "route53",
     #    aws_access_key_id=temp_credentials["AccessKeyId"],
     #    aws_secret_access_key=temp_credentials["SecretAccessKey"],
     #    aws_session_token=temp_credentials["SessionToken"],
-    #)
-    #3. Call the below call w/ new r53 resource, for ex: use r53_resource.change_resource_record_sets, instead of the below r53.change_resource_record_sets
+    # )
+    # 3. Call the below call w/ new r53 resource, for ex: use r53_resource.change_resource_record_sets, instead of the below r53.change_resource_record_sets
+
+    changes = [
+        {
+            'Action': 'UPSERT',
+            'ResourceRecordSet': {
+                'Name': alias,
+                'Type': 'A',
+                'AliasTarget': {
+                    'HostedZoneId': 'Z2FDTNDATAQYW2',
+                    'DNSName': new_domain,
+                    'EvaluateTargetHealth': False
+                }
+            }
+        }
+    ]
+
+    # Add IPv6 records if enabled
+    if ipv6_enabled:
+        print("Adding IPv6 (AAAA) records...")
+        changes.append({
+            'Action': 'UPSERT',
+            'ResourceRecordSet': {
+                'Name': alias,
+                'Type': 'AAAA',
+                'AliasTarget': {
+                    'HostedZoneId': 'Z2FDTNDATAQYW2',
+                    'DNSName': new_domain,
+                    'EvaluateTargetHealth': False
+                }
+            }
+        })
 
     response = r53.change_resource_record_sets(
-    HostedZoneId=hostedzoneID,
-    ChangeBatch={
-        'Comment': 'string',
-        'Changes': [
-            {
-                'Action': 'DELETE',
-                'ResourceRecordSet': {
-                    'Name': alias,
-                    'Type': 'A',
-                    'AliasTarget': {
-                        'HostedZoneId': 'Z2FDTNDATAQYW2',
-                        'DNSName': old_domain,
-                        'EvaluateTargetHealth': False
-                    }
-                }
-            },
-                        {
-                'Action': 'CREATE',
-                'ResourceRecordSet': {
-                    'Name': alias,
-                    'Type': 'A',
-                    'AliasTarget': {
-                        'HostedZoneId': 'Z2FDTNDATAQYW2',
-                        'DNSName':new_domain,
-                        'EvaluateTargetHealth': False
-                    }
-                }
-            },
-        ]
-    }
-)
+        HostedZoneId=hostedzoneID,
+        ChangeBatch={
+            'Comment': 'CloudFront CNAME swap with IPv4 and IPv6 support',
+            'Changes': changes
+        }
+    )
 
 
 def main():
-    cloudfrontID = sys.argv[1]
-    hostedzoneID = sys.argv[2]
-    old_domain = sys.argv[3]
-    new_domain = sys.argv[4]
-    alias = sys.argv[5]
-    while checkAlias(cloudfrontID, alias) != True:
-        print("Checking...")
-    updateRecord(hostedzoneID, old_domain, new_domain, alias)
-    print("Record Updated!")
+    # Check if correct number of arguments provided
+    if len(sys.argv) != 5:
+        print("Error: Incorrect number of arguments provided.")
+        print("\nUsage:")
+        print("    python3 cloudfront_dns_automation.py <new-distribution-id> <route53-hosted-zone-id>")
+        print("                                        <new-cloudfront-domain> <alias-alternate-name>")
+        print("\nExample:")
+        print(
+            "    python3 cloudfront_dns_automation.py EZDLMTR1D3MHD Z00646902JW6C5QG3Q2NG")
+        print("                                        d2mz62fpvuge8k.cloudfront.net.")
+        print("                                        www.example.com")
+        sys.exit(1)
+
+    try:
+        cloudfrontID = sys.argv[1]
+        hostedzoneID = sys.argv[2]
+        new_domain = sys.argv[3]
+        alias = sys.argv[4]
+
+        # Validate all input parameters
+        validate_inputs(cloudfrontID, hostedzoneID, new_domain, alias)
+
+        print("All required parameters exist. Starting CloudFront monitoring...")
+        print(f"Monitoring distribution: {cloudfrontID}")
+        print(
+            f"Validating domain and waiting for alias '{alias}' to be available...")
+
+        ipv6_enabled = checkAlias(cloudfrontID, alias, new_domain)
+
+        if ipv6_enabled:
+            print("Alias found! Updating DNS records (IPv4 and IPv6)...")
+        else:
+            print("Alias found! Updating DNS record (IPv4 only)...")
+
+        updateRecord(hostedzoneID, new_domain, alias, ipv6_enabled)
+
+        if ipv6_enabled:
+            print("DNS records updated! (A and AAAA records)")
+        else:
+            print("DNS record updated! (A record only)")
+
+    except ValueError as e:
+        print(f"Validation Error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


This Python automation script delivers a zero-downtime approach for CloudFront CNAME migrations by automatically updating DNS records the moment AWS Support completes a CNAME swap. Instead of manual coordination that leads to inevitable downtime, the python script continuously monitors your target CloudFront distribution and instantly updates Route 53 records when the migration occurs.